### PR TITLE
Style issues

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - enabling new `searchOptions.byPropertyName` prop in default `searchOptions`
+- style-fix: let long item names break over multiple lines within a column
+- style-fix: disable the "outline" on `column` and `colview` (they were only shown in some browsers)
 
 ## [2.1.0] - 2019-05-01
 ### Added

--- a/src/component/Inspector.scss
+++ b/src/component/Inspector.scss
@@ -36,6 +36,7 @@
         display: flex;
         overflow-x: auto;
         margin-right: -1px;
+        outline: none;
     }
     &-item {
         flex-shrink: 0;
@@ -90,6 +91,7 @@
             min-width: $columnWidth;
             border-right: $innerBorder;
             overflow-y: auto;
+            outline: none;
         }
         &-placeholder {
             opacity: 0;

--- a/src/component/Inspector.scss
+++ b/src/component/Inspector.scss
@@ -65,11 +65,15 @@
             display: block;
             flex-grow: 1;
             padding: $verticalItemSpacingInside $spacingInside $verticalItemSpacingInside $leadItemSpacingInside;
+            word-break: break-word;
         }
         &-icon {
             display: block;
             flex-grow: 0;
             width: 1em;
+            min-width: 1em;
+            height: 1.69em;
+            margin-top: auto;
         }
         &.has-nested-items > &-content > &-icon {
             background-color: #7f7f7f;


### PR DESCRIPTION
There are two (minor) style issues:

1. Item names that exceed a single column's width result in:
    - horizontal scroll-bars within the column and
    - the arrow/triangle icon indicating contained items is being hidden
2. Clicking on a `column` or the `colview` background shows some selection outline/box in some browsers (e.g. Safari).

----

The item styles should be adjusted to `word-break: break-word` – with the indicator icon being bottom-aligned.
`outline: none` should be set on the `column` and `colview` classes.