### PR TITLE
Use @wessberg/rollup-plugin-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
         "/build"
     ],
     "browserslist": [
-        ">0.2%",
-        "not dead",
-        "not ie <= 11",
-        "not op_mini all"
+        "defaults"
     ],
     "devDependencies": {
         "@mdx-js/loader": "~1.5.1",
@@ -55,6 +52,7 @@
         "@typescript-eslint/eslint-plugin": "~2.5.0",
         "@typescript-eslint/parser": "~2.5.0",
         "@typescript-eslint/typescript-estree": "~2.5.0",
+        "@wessberg/rollup-plugin-ts": "~1.1.73",
         "awesome-typescript-loader": "~5.2.1",
         "babel-loader": "~8.0.6",
         "coveralls": "~3.0.6",
@@ -76,12 +74,8 @@
         "prettier": "~1.18.2",
         "react-docgen-typescript-loader": "~3.3.0",
         "rollup": "~1.26.0",
-        "rollup-plugin-commonjs": "~10.1.0",
-        "rollup-plugin-node-resolve": "~5.2.0",
         "rollup-plugin-postcss": "~2.0.3",
         "rollup-plugin-terser": "~5.1.2",
-        "rollup-plugin-typescript2": "~0.24.3",
-        "rollup-plugin-uglify": "~6.0.3",
         "sass-loader": "~8.0.0",
         "style-loader": "~1.0.0",
         "stylelint": "~11.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,78 +1,41 @@
-import commonjs from "rollup-plugin-commonjs";
 import postcss from "rollup-plugin-postcss";
-import resolve from "rollup-plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
-import typescript from "rollup-plugin-typescript2";
-import { uglify } from "rollup-plugin-uglify";
+import typescript from "@wessberg/rollup-plugin-ts";
 
 import packageJSON from "./package.json";
-
-const input = "./src/index.ts";
-const external = [
-    // ensure peer dependencies are declared as externals
-    ...Object.keys(packageJSON.peerDependencies),
-    // same for actual dependencies, to allow for dependency resolution/de-duplication by consumers
-    ...Object.keys(packageJSON.dependencies)
-];
-const postcssOptions = {
-    extract: false,
-    extensions: [".scss"],
-    minimize: true
-};
-const typescriptOptions = {
-    // eslint-disable-next-line global-require
-    typescript: require("typescript")
-};
 
 export default [
     // CommonJS
     {
-        input,
-        output: {
-            file: packageJSON.main,
-            format: "cjs",
-            sourcemap: true
-        },
-        external,
+        input: "./src/index.ts",
+        output: [
+            {
+                file: packageJSON.main,
+                format: "cjs",
+                sourcemap: true
+            },
+            {
+                file: packageJSON.module,
+                format: "es",
+                exports: "named",
+                sourcemap: true
+            }
+        ],
+        external: [
+            // ensure peer dependencies are declared as externals
+            ...Object.keys(packageJSON.peerDependencies),
+            // same for actual dependencies, to allow for dependency resolution/de-duplication by consumers
+            ...Object.keys(packageJSON.dependencies)
+        ],
         plugins: [
             // collect styles from SCSS, minimise them and include them in the JS module (i.e. not as separate .css file)
-            postcss(postcssOptions),
-            // compile typescript into vanilla javascript
-            typescript({
-                ...typescriptOptions,
-                tsconfigOverride: {
-                    compilerOptions: {
-                        target: "es5"
-                    }
-                }
+            postcss({
+                extract: false,
+                extensions: [".scss"],
+                minimize: true
             }),
-            // resolve dependencies that are ES modules
-            resolve(),
-            // resolve dependencies that are (legacy) CommonJS modules
-            commonjs(),
-            // minify to reduce size
-            uglify()
-        ]
-    },
-    // ES Module
-    {
-        input,
-        output: {
-            file: packageJSON.module,
-            format: "es",
-            exports: "named",
-            sourcemap: true
-        },
-        external,
-        plugins: [
-            // collect styles from SCSS, minimise them and include them in the JS module (i.e. not as separate .css file)
-            postcss(postcssOptions),
-            // compile typescript into vanilla javascript
-            typescript(typescriptOptions),
-            // resolve dependencies that are ES modules
-            resolve(),
-            // resolve dependencies that are (legacy) CommonJS modules
-            commonjs(),
+            // compile typescript into vanilla javascript and produce a single .d.ts file
+            typescript({}),
             // discard unused parts of the code
             terser()
         ]


### PR DESCRIPTION
Getting rid of four separate plugins instead
Also allowing same configuration for CJS and ES bundles