### PR TITLE
Include other keywords alongside $ref

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - support `$defs` (introduced in Draft 2019-09) as alternative to `definitions` keyword
+- include other keywords alongside `$ref` (as per Draft 2019-09)
 
 ## [4.1.0] - 2019-11-26
 ### Added

--- a/src/model/schemaUtils.ts
+++ b/src/model/schemaUtils.ts
@@ -88,7 +88,7 @@ function createGroupFromRawSchemaArray(
         .filter((rawSchemaPart) => typeof rawSchemaPart !== "boolean")
         // convert each part in the group to a JsonSchema instance and (recursively) get its group information
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        .map((rawSchemaPart) => createGroupFromSchema(new JsonSchema(rawSchemaPart as RawJsonSchema, parserConfig, scope)))
+        .map((rawSchemaPart) => createGroupFromSchema(new JsonSchema(rawSchemaPart, parserConfig, scope)))
         // add group info from each schema part to the created group representation
         .forEach(group.with.bind(group));
     return group;
@@ -112,12 +112,11 @@ export function createGroupFromSchema(schema: JsonSchema): JsonSchemaAllOfGroup 
     if (!isNonEmptyObject(rawSchema)) {
         return new JsonSchemaAllOfGroup();
     }
+    const result = new JsonSchemaAllOfGroup().with(schema);
     if (rawSchema.$ref) {
         const referencedSchema = scope.find(rawSchema.$ref);
-        // this schema is just a reference to another separately defined schema
-        return createGroupFromSchema(referencedSchema);
+        result.with(createGroupFromSchema(referencedSchema));
     }
-    const result = new JsonSchemaAllOfGroup().with(schema);
     if (rawSchema.allOf) {
         result.with(createGroupFromRawSchemaArray(JsonSchemaAllOfGroup, schema, rawSchema.allOf));
     }

--- a/src/model/searchUtils.ts
+++ b/src/model/searchUtils.ts
@@ -36,10 +36,6 @@ export function createRecursiveFilterFunction(
         if (flatSearchFilter && flatSearchFilter(rawSchema, includeNestedOptionals)) {
             return true;
         }
-        if (rawSchema.$ref) {
-            // if there is a $ref, no other fields are being expected to be present - and the referenced sub-schema is checked separately
-            return false;
-        }
         const searchInParts = (groupKey: "allOf" | "oneOf" | "anyOf"): boolean => {
             const partsArray = getValueFromRawJsonSchema(rawSchema, groupKey);
             return (

--- a/test/component/renderDataUtils.test.ts
+++ b/test/component/renderDataUtils.test.ts
@@ -136,9 +136,13 @@ describe("createRenderDataBuilder()", () => {
             expect(Object.keys(secondColumn.items)).toHaveLength(1);
             expect(secondColumn.items["Item Three"]).toBeInstanceOf(JsonSchemaGroup);
             const secondColumnItemThree = secondColumn.items["Item Three"] as JsonSchemaGroup;
-            expect(secondColumnItemThree.entries).toHaveLength(1);
+            expect(secondColumnItemThree.entries).toHaveLength(3);
             expect(secondColumnItemThree.entries[0]).toBeInstanceOf(JsonSchema);
-            expect((secondColumnItemThree.entries[0] as JsonSchema).schema).toEqual(quxSchema);
+            expect((secondColumnItemThree.entries[0] as JsonSchema).schema).toEqual({ $ref: "https://foo.bar/foobar#/$defs/qux" });
+            expect(secondColumnItemThree.entries[1]).toBeInstanceOf(JsonSchema);
+            expect((secondColumnItemThree.entries[1] as JsonSchema).schema).toEqual({ $ref: "https://foo.bar/foobar/qux" });
+            expect(secondColumnItemThree.entries[2]).toBeInstanceOf(JsonSchema);
+            expect((secondColumnItemThree.entries[2] as JsonSchema).schema).toEqual(quxSchema);
             expect(secondColumn.onSelect).toBeDefined();
             secondColumn.onSelect(null);
             expect(lastCalledOnSelectColumnIndex).toBe(1);

--- a/test/model/searchUtils.test.ts
+++ b/test/model/searchUtils.test.ts
@@ -328,10 +328,11 @@ describe("createFilterFunctionForSchema()", () => {
                         items: { $ref: "#" }
                     },
                     Two: {
-                        items: { title: "Nothing" }
+                        title: "Nothing"
                     },
                     Three: {
-                        allOf: [{ $ref: "#/$defs/Two" }, { $ref: "https://unique-schema-identifier#" }]
+                        $ref: "#/$defs/Two",
+                        allOf: [true, { $ref: "https://unique-schema-identifier#" }]
                     }
                 }
             },


### PR DESCRIPTION
Part of introducing support for Draft 2019-19 (#67).

Previously, some structures (e.g. `allOf`/`anyOf`/`oneOf`) were ignored if they were defined alongside `$ref`.
Now, other keywords are explicitly allowed.