### PR TITLE
Fixing exported type definitions and avoid empty details section

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Exported type definitions should include main `<Inspector>` component and its props
+- Borders of "Details" block should not be shown if there is no selection and no `renderEmptyDetails` prop was provided
+- Borders of "Details" block should not be shown if there is no selection and `renderEmptyDetails` returns no content to be shown
+- Borders of "Details" block should not be shown if there is a selection and `renderSelectionDetails` returns no content to be shown
 
 ## [4.2.0] - 2019-12-04
 ### Added

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "start": "start-storybook -p 9001 -c .storybook",
         "build": "rollup -c",
         "lint": "tsc --noEmit && npm run lint-code && npm run lint-styles",
-        "lint-code": "eslint '{src,test,stories}/**/*.{js,ts,tsx}' --report-unused-disable-directives",
+        "lint-code": "eslint {src,test,stories}/**/*.{js,ts,tsx} --report-unused-disable-directives",
         "lint-styles": "stylelint src stories/**/*.*css stories/**/*.mdx",
         "lint-fix": "npm run lint-code -- --fix",
         "test": "jest",

--- a/src/component/Inspector.scss
+++ b/src/component/Inspector.scss
@@ -218,4 +218,7 @@
             }
         }
     }
+    & .nothing-to-show {
+        display: none;
+    }
 }

--- a/src/component/InspectorDetails.tsx
+++ b/src/component/InspectorDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import classNames from "classnames";
 
 import { InspectorDetailsContent } from "./InspectorDetailsContent";
 import { JsonSchemaGroup } from "../model/JsonSchemaGroup";
@@ -22,24 +23,29 @@ export const InspectorDetails: React.FunctionComponent<{
             optionIndexes = trailingSelectionColumn.selectedItem as Array<number>;
         }
     }
+    let detailsContent: React.ReactElement;
+    if (itemSchemaGroup && renderSelectionDetails) {
+        detailsContent = renderSelectionDetails({
+            itemSchemaGroup,
+            selectionColumnIndex,
+            columnData,
+            optionIndexes
+        });
+    } else if (itemSchemaGroup && !renderSelectionDetails) {
+        detailsContent = (
+            <InspectorDetailsContent itemSchemaGroup={itemSchemaGroup} selectionColumnIndex={selectionColumnIndex} columnData={columnData} />
+        );
+    } else if (!itemSchemaGroup && renderEmptyDetails) {
+        detailsContent = renderEmptyDetails({
+            rootColumnSchemas: columnData.length ? (columnData[0] as RenderItemsColumn).items : {}
+        });
+    }
+    const wrapperClassName = classNames("jsonschema-inspector-details", {
+        "nothing-to-show": !detailsContent
+    });
     return (
-        <div className="jsonschema-inspector-details">
-            {itemSchemaGroup &&
-                renderSelectionDetails &&
-                renderSelectionDetails({
-                    itemSchemaGroup,
-                    selectionColumnIndex,
-                    columnData,
-                    optionIndexes
-                })}
-            {itemSchemaGroup && !renderSelectionDetails && (
-                <InspectorDetailsContent itemSchemaGroup={itemSchemaGroup} selectionColumnIndex={selectionColumnIndex} columnData={columnData} />
-            )}
-            {!itemSchemaGroup &&
-                renderEmptyDetails &&
-                renderEmptyDetails({
-                    rootColumnSchemas: columnData.length ? (columnData[0] as RenderItemsColumn).items : {}
-                })}
+        <div className={wrapperClassName}>
+            {detailsContent}
         </div>
     );
 };

--- a/src/component/InspectorDetails.tsx
+++ b/src/component/InspectorDetails.tsx
@@ -43,9 +43,5 @@ export const InspectorDetails: React.FunctionComponent<{
     const wrapperClassName = classNames("jsonschema-inspector-details", {
         "nothing-to-show": !detailsContent
     });
-    return (
-        <div className={wrapperClassName}>
-            {detailsContent}
-        </div>
-    );
+    return <div className={wrapperClassName}>{detailsContent}</div>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { Inspector as InspectorComponent } from "./component/Inspector";
 import { getFieldValueFromSchemaGroup } from "./model/schemaUtils";
 import { minimumValue, maximumValue, commonValues, listValues } from "./model/utils";
 
@@ -8,7 +7,7 @@ import { KeysOfRawJsonSchema, KeysOfRawJsonSchemaWithValuesOf } from "./types/Ra
 /**
  * Main Inspector component (with numerous props).
  */
-export const Inspector = InspectorComponent;
+export { Inspector } from "./component/Inspector";
 
 /**
  * Extract single minimum numeric value from a certain field in the (selected) schema parts of the given schema group.

--- a/stories/Inspector.RenderSelectionDetails.stories.mdx
+++ b/stories/Inspector.RenderSelectionDetails.stories.mdx
@@ -47,3 +47,19 @@ Via `renderSelectionDetails` you can define your own component to be displayed o
         />
     </Story>
 </Preview>
+
+### disabled
+If `renderSelectionDetails` returns nothing (e.g. `null`), the details panel on the right will be hidden.
+
+<Preview>
+    <Story name="disabled">
+        <Inspector
+            schemas={{
+                Shop: shopSelectionSchema
+            }}
+            defaultSelectedItems={["Shop", "inventory"]}
+            renderSelectionDetails={() => null}
+            onSelect={action("onSelect")}
+        />
+    </Story>
+</Preview>

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@typescript-eslint/no-empty-function": "off",
         "class-methods-use-this": "off",
         "import/no-extraneous-dependencies": "off",
         "indent": ["error", 4, { "ignoredNodes": ["TemplateLiteral"] }],

--- a/test/component/InspectorDetails.test.tsx
+++ b/test/component/InspectorDetails.test.tsx
@@ -28,6 +28,7 @@ describe("renders correctly", () => {
         it("shows nothing by default", () => {
             const component = shallow(<InspectorDetails columnData={[]} />);
             expect(component.children().exists()).toBe(false);
+            expect(component.hasClass("nothing-to-show")).toBe(true);
         });
         it("applies custom renderEmptyDetails", () => {
             const component = shallow(
@@ -39,6 +40,17 @@ describe("renders correctly", () => {
                 />
             );
             expect(component.find(".custom-empty-details").text()).toBe("0");
+            expect(component.hasClass("nothing-to-show")).toBe(false);
+        });
+        it("allows for renderEmptyDetails to return nothing", () => {
+            const component = shallow(
+                <InspectorDetails
+                    columnData={[]}
+                    renderEmptyDetails={(): React.ReactElement => null}
+                />
+            );
+            expect(component.children().exists()).toBe(false);
+            expect(component.hasClass("nothing-to-show")).toBe(true);
         });
     });
     describe("with no selection", () => {
@@ -57,6 +69,7 @@ describe("renders correctly", () => {
         it("shows nothing by default", () => {
             const component = shallow(<InspectorDetails columnData={columnData} />);
             expect(component.children().exists()).toBe(false);
+            expect(component.hasClass("nothing-to-show")).toBe(true);
         });
         it("applies custom renderEmptyDetails", () => {
             const component = shallow(
@@ -68,6 +81,17 @@ describe("renders correctly", () => {
                 />
             );
             expect(component.find(".custom-empty-details").text()).toBe("1");
+            expect(component.hasClass("nothing-to-show")).toBe(false);
+        });
+        it("allows for renderEmptyDetails to return nothing", () => {
+            const component = shallow(
+                <InspectorDetails
+                    columnData={[]}
+                    renderEmptyDetails={(): React.ReactElement => null}
+                />
+            );
+            expect(component.children().exists()).toBe(false);
+            expect(component.hasClass("nothing-to-show")).toBe(true);
         });
     });
     describe("with array item selection", () => {
@@ -93,6 +117,7 @@ describe("renders correctly", () => {
             expect(columnData).toEqual(columnDataProp);
             expect(itemSchemaGroup).toEqual(((columnDataProp[1] as unknown) as RenderItemsColumn).items["[0]"]);
             expect(selectionColumnIndex).toEqual(1);
+            expect(component.hasClass("nothing-to-show")).toBe(false);
         });
         it("applies custom renderSelectionDetails", () => {
             const renderSelectionDetails = jest.fn(() => <span className="custom-selection-details" />);
@@ -107,6 +132,17 @@ describe("renders correctly", () => {
             expect(columnData).toEqual(columnDataProp);
             expect(itemSchemaGroup).toEqual(((columnDataProp[1] as unknown) as RenderItemsColumn).items["[0]"]);
             expect(selectionColumnIndex).toBe(1);
+            expect(component.hasClass("nothing-to-show")).toBe(false);
+        });
+        it("allows for renderSelectionDetails to return nothing", () => {
+            const component = shallow(
+                <InspectorDetails
+                    columnData={columnDataProp}
+                    renderSelectionDetails={(): React.ReactElement => null}
+                />
+            );
+            expect(component.children().exists()).toBe(false);
+            expect(component.hasClass("nothing-to-show")).toBe(true);
         });
     });
     describe("with option selection", () => {
@@ -134,6 +170,7 @@ describe("renders correctly", () => {
             expect(columnData).toEqual(columnDataProp);
             expect((itemSchemaGroup.entries[0] as JsonSchema).schema).toEqual(schema);
             expect(selectionColumnIndex).toEqual(1);
+            expect(component.hasClass("nothing-to-show")).toBe(false);
         });
         it("applies custom renderSelectionDetails", () => {
             const renderSelectionDetails = jest.fn(() => <span className="custom-selection-details" />);
@@ -148,6 +185,17 @@ describe("renders correctly", () => {
             expect(columnData).toEqual(columnDataProp);
             expect((itemSchemaGroup.entries[0] as JsonSchema).schema).toEqual(schema);
             expect(selectionColumnIndex).toBe(1);
+            expect(component.hasClass("nothing-to-show")).toBe(false);
+        });
+        it("allows for renderSelectionDetails to return nothing", () => {
+            const component = shallow(
+                <InspectorDetails
+                    columnData={columnDataProp}
+                    renderSelectionDetails={(): React.ReactElement => null}
+                />
+            );
+            expect(component.children().exists()).toBe(false);
+            expect(component.hasClass("nothing-to-show")).toBe(true);
         });
     });
 });

--- a/test/component/InspectorDetails.test.tsx
+++ b/test/component/InspectorDetails.test.tsx
@@ -43,12 +43,7 @@ describe("renders correctly", () => {
             expect(component.hasClass("nothing-to-show")).toBe(false);
         });
         it("allows for renderEmptyDetails to return nothing", () => {
-            const component = shallow(
-                <InspectorDetails
-                    columnData={[]}
-                    renderEmptyDetails={(): React.ReactElement => null}
-                />
-            );
+            const component = shallow(<InspectorDetails columnData={[]} renderEmptyDetails={(): React.ReactElement => null} />);
             expect(component.children().exists()).toBe(false);
             expect(component.hasClass("nothing-to-show")).toBe(true);
         });
@@ -84,12 +79,7 @@ describe("renders correctly", () => {
             expect(component.hasClass("nothing-to-show")).toBe(false);
         });
         it("allows for renderEmptyDetails to return nothing", () => {
-            const component = shallow(
-                <InspectorDetails
-                    columnData={[]}
-                    renderEmptyDetails={(): React.ReactElement => null}
-                />
-            );
+            const component = shallow(<InspectorDetails columnData={[]} renderEmptyDetails={(): React.ReactElement => null} />);
             expect(component.children().exists()).toBe(false);
             expect(component.hasClass("nothing-to-show")).toBe(true);
         });
@@ -135,12 +125,7 @@ describe("renders correctly", () => {
             expect(component.hasClass("nothing-to-show")).toBe(false);
         });
         it("allows for renderSelectionDetails to return nothing", () => {
-            const component = shallow(
-                <InspectorDetails
-                    columnData={columnDataProp}
-                    renderSelectionDetails={(): React.ReactElement => null}
-                />
-            );
+            const component = shallow(<InspectorDetails columnData={columnDataProp} renderSelectionDetails={(): React.ReactElement => null} />);
             expect(component.children().exists()).toBe(false);
             expect(component.hasClass("nothing-to-show")).toBe(true);
         });
@@ -188,12 +173,7 @@ describe("renders correctly", () => {
             expect(component.hasClass("nothing-to-show")).toBe(false);
         });
         it("allows for renderSelectionDetails to return nothing", () => {
-            const component = shallow(
-                <InspectorDetails
-                    columnData={columnDataProp}
-                    renderSelectionDetails={(): React.ReactElement => null}
-                />
-            );
+            const component = shallow(<InspectorDetails columnData={columnDataProp} renderSelectionDetails={(): React.ReactElement => null} />);
             expect(component.children().exists()).toBe(false);
             expect(component.hasClass("nothing-to-show")).toBe(true);
         });


### PR DESCRIPTION
- Exported type definitions should include main `<Inspector>` component and its props
- Borders of "Details" block should not be shown if there is no selection and no `renderEmptyDetails` prop was provided
- Borders of "Details" block should not be shown if there is no selection and `renderEmptyDetails` returns no content to be shown
- Borders of "Details" block should not be shown if there is a selection and `renderSelectionDetails` returns no content to be shown