### PR TITLE
Basic support for $recursiveRef and fixed type definition for draft 2019-09

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Exported type definitions should include main `<Inspector>` component and its props
+- Include type definition for Draft 2019-09 for expected props
 - Borders of "Details" block should not be shown if there is no selection and no `renderEmptyDetails` prop was provided
 - Borders of "Details" block should not be shown if there is no selection and `renderEmptyDetails` returns no content to be shown
 - Borders of "Details" block should not be shown if there is a selection and `renderSelectionDetails` returns no content to be shown

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Draft 2019-09: basic support for `$recursiveRef` as alias for `$ref` (not yet covering advanced use cases)
+
 ### Fixed
 - Exported type definitions should include main `<Inspector>` component and its props
 - Include type definition for Draft 2019-09 for expected props

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please refer to the more detailed listing below regarding particular keywords.
 | `$anchor` | Yes | allowed as sub-schema reference in `$ref` (as per Draft 2019-09) when preceded by `#`, but not displayed; *ignored* if specified anywhere but in the root schema or inside an entry in `$defs`/`definitions` |
 | `$ref` | Yes | used to look-up re-usable sub-schemas transparently (i.e. not displayed), supporting:<ul><li>`#` or the root `$id`/`id` value as root schema references,</li><li>`#/$defs/<name-of-definition>`/`#/definitions/<name-of-definition>` or the respective `$id`/`id` value from within the `$defs`/`definitions` for sub-schemas,</li><li>absolute URIs are supported as long as those separate schemas are provided via the `referenceSchemas` prop (and their respective root `$id`/`id` matches the given `$ref`)</li><li>absolute URIs ending with `#/$defs/<name-of-definition>`/`#/definitions/<name-of-definition>` or `#<anchor>` are also supported via the `referenceSchemas` prop</li></ul> |
 | `$recursiveAnchor` | - | *ignored* |
-| `$recursiveRef` | - | *ignored* |
+| `$recursiveRef` | Partially | treated as alias for `$ref` but not yet for advanced scenarios involving `$recursiveAnchor` (as per Draft 2019-09) |
 | `$defs`| Yes | used to provide re-usable sub-schemas that are being referenced via `$ref` (only in the respective root schemas) (as per Draft 2019-09) |
 | `definitions`| Yes | used to provide re-usable sub-schemas that are being referenced via `$ref` (only in the respective root schemas) (as per Draft 4, 6 or 7) |
 | `properties`| Yes | used to populate the whole structure to be traversed |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "start": "start-storybook -p 9001 -c .storybook",
         "build": "rollup -c",
         "lint": "tsc --noEmit && npm run lint-code && npm run lint-styles",
-        "lint-code": "eslint {src,test,stories}/**/*.{js,ts,tsx} --report-unused-disable-directives",
+        "lint-code": "eslint {src,test}/**/*.{ts,tsx} --report-unused-disable-directives",
         "lint-styles": "stylelint src stories/**/*.*css stories/**/*.mdx",
         "lint-fix": "npm run lint-code -- --fix",
         "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-jsonschema-inspector",
-    "version": "4.2.1-SNAPSHOT",
+    "version": "4.3.0-SNAPSHOT",
     "description": "View component for traversing/searching in a JSON Schema",
     "homepage": "https://CarstenWickner.github.io/react-jsonschema-inspector",
     "author": "Carsten Wickner",

--- a/src/model/schemaUtils.ts
+++ b/src/model/schemaUtils.ts
@@ -117,6 +117,12 @@ export function createGroupFromSchema(schema: JsonSchema): JsonSchemaAllOfGroup 
         const referencedSchema = scope.find(rawSchema.$ref);
         result.with(createGroupFromSchema(referencedSchema));
     }
+    const recursiveRef = getValueFromRawJsonSchema(rawSchema, "$recursiveRef");
+    if (recursiveRef) {
+        // under some circumstances, $recursiveRef behaves like $ref which is a good starting point for now
+        const referencedSchema = scope.find(recursiveRef);
+        result.with(createGroupFromSchema(referencedSchema));
+    }
     if (rawSchema.allOf) {
         result.with(createGroupFromRawSchemaArray(JsonSchemaAllOfGroup, schema, rawSchema.allOf));
     }

--- a/src/model/searchUtils.ts
+++ b/src/model/searchUtils.ts
@@ -85,9 +85,17 @@ export function collectReferencedSubSchemas(schema: JsonSchema, includeNestedOpt
     const references: Map<JsonSchema, boolean> = new Map();
     // collect all referenced sub-schemas
     const collectReferences = (rawSubSchema: RawJsonSchema, isIncludingOptionals?: boolean): boolean => {
+        // add any referenced schemas to the result set
         if (rawSubSchema.$ref) {
-            // add referenced schema to the result set
             const targetSchema = schema.scope.find(rawSubSchema.$ref);
+            if (references.get(targetSchema) !== true) {
+                references.set(targetSchema, !!isIncludingOptionals);
+            }
+        }
+        const recursiveRef = getValueFromRawJsonSchema(rawSubSchema, "$recursiveRef");
+        if (recursiveRef) {
+            // under some circumstances, $recursiveRef behaves like $ref which is a good starting point for now
+            const targetSchema = schema.scope.find(recursiveRef);
             if (references.get(targetSchema) !== true) {
                 references.set(targetSchema, !!isIncludingOptionals);
             }

--- a/src/types/JSONSchema201909.ts
+++ b/src/types/JSONSchema201909.ts
@@ -10,7 +10,7 @@ export interface JSONSchema201909 {
     $ref?: string;
     $schema?: string;
     $vocabulary?: {
-        [key: string]: string;
+        [key: string]: boolean;
     };
     $comment?: string;
 

--- a/src/types/JSONSchema201909.ts
+++ b/src/types/JSONSchema201909.ts
@@ -1,0 +1,94 @@
+import { JSONSchema7TypeName, JSONSchema7Type } from "json-schema";
+
+/*
+ * Temporary type definition for Draft 2019-09 until a proper one can be imported from `@types/json-schema`.
+ */
+export type JSONSchema201909Definition = JSONSchema201909 | boolean;
+export interface JSONSchema201909 {
+    $id?: string;
+    $anchor?: string;
+    $ref?: string;
+    $schema?: string;
+    $vocabulary?: {
+        [key: string]: string;
+    };
+    $comment?: string;
+
+    $recursiveRef?: string;
+    $recursiveAnchor?: string;
+
+    type?: JSONSchema7TypeName | JSONSchema7TypeName[];
+    enum?: JSONSchema7Type[];
+    const?: JSONSchema7Type;
+
+    maximum?: number;
+    exclusiveMaximum?: number;
+    minimum?: number;
+    exclusiveMinimum?: number;
+
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+
+    items?: JSONSchema201909Definition | JSONSchema201909Definition[];
+    additionalItems?: JSONSchema201909Definition;
+    unevaluatedItems?: JSONSchema201909Definition;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    contains?: JSONSchema201909;
+    maxContains?: number;
+    minContains?: number;
+
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    properties?: {
+        [key: string]: JSONSchema201909Definition;
+    };
+    patternProperties?: {
+        [key: string]: JSONSchema201909Definition;
+    };
+    additionalProperties?: JSONSchema201909Definition;
+    unevaluatedProperties?: JSONSchema201909Definition;
+    // deprecated but still supported for backward compatibility
+    dependencies?: {
+        [key: string]: JSONSchema201909Definition | string[];
+    };
+    dependentSchemas?: {
+        [key: string]: JSONSchema201909Definition;
+    };
+    dependentRequired?: {
+        [key: string]: string[];
+    };
+    propertyNames?: JSONSchema201909Definition;
+
+    if?: JSONSchema201909Definition;
+    then?: JSONSchema201909Definition;
+    else?: JSONSchema201909Definition;
+
+    allOf?: JSONSchema201909Definition[];
+    anyOf?: JSONSchema201909Definition[];
+    oneOf?: JSONSchema201909Definition[];
+    not?: JSONSchema201909Definition;
+
+    format?: string;
+
+    contentMediaType?: string;
+    contentEncoding?: string;
+
+    $defs?: {
+        [key: string]: JSONSchema201909Definition;
+    };
+    // deprecated but still supported for backward compatibility
+    definitions?: {
+        [key: string]: JSONSchema201909Definition;
+    };
+
+    title?: string;
+    description?: string;
+    default?: JSONSchema7Type;
+    readOnly?: boolean;
+    writeOnly?: boolean;
+    examples?: JSONSchema7Type;
+}

--- a/src/types/RawJsonSchema.ts
+++ b/src/types/RawJsonSchema.ts
@@ -1,22 +1,16 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
 import { KeysWithValueType, KnownKeys } from "./typeUtils";
-
-/**
- * Temporary type definition for Draft 2019-09 until a proper one can be imported like the others – just to satisfy TypeScript.
- */
-export interface JSONSchema8 extends JSONSchema7 {
-    $defs: { [key: string]: JSONSchema8 | boolean };
-}
+import { JSONSchema201909 } from "./JSONSchema201909";
 
 /**
  * Type representing a JSON Schema Draft 7 (with backwards-compatibility down to Draft 4).
  */
-export type RawJsonSchema = JSONSchema4 | JSONSchema6 | JSONSchema7 | JSONSchema8;
+export type RawJsonSchema = JSONSchema4 | JSONSchema6 | JSONSchema7 | JSONSchema201909;
 
 /**
  * All allowed keys for the supported JSON Schema versions.
  */
-export type KeysOfRawJsonSchema = KnownKeys<JSONSchema4 & JSONSchema6 & JSONSchema7 & JSONSchema8>;
+export type KeysOfRawJsonSchema = KnownKeys<JSONSchema4 & JSONSchema6 & JSONSchema7 & JSONSchema201909>;
 
 /**
  * Type look-up for a particular key in any of the supported JSON Schema versions.
@@ -25,7 +19,7 @@ export type TypeInRawJsonSchema<K> =
     | (K extends KnownKeys<JSONSchema4> ? JSONSchema4[K] : never)
     | (K extends KnownKeys<JSONSchema6> ? JSONSchema6[K] : never)
     | (K extends KnownKeys<JSONSchema7> ? JSONSchema7[K] : never)
-    | (K extends KnownKeys<JSONSchema8> ? JSONSchema8[K] : never);
+    | (K extends KnownKeys<JSONSchema201909> ? JSONSchema201909[K] : never);
 
 /**
  * Type-safe value look-up for a particular key in a given JSON Schema.
@@ -35,14 +29,17 @@ export type TypeInRawJsonSchema<K> =
  * @returns {*} value in schema
  */
 export function getValueFromRawJsonSchema<K extends KeysOfRawJsonSchema>(rawSchema: RawJsonSchema, key: K): TypeInRawJsonSchema<K> {
-    return ((rawSchema as JSONSchema4 & JSONSchema6 & JSONSchema7 & JSONSchema8)[key] as unknown) as TypeInRawJsonSchema<K>;
+    return ((rawSchema as JSONSchema4 & JSONSchema6 & JSONSchema7 & JSONSchema201909)[key] as unknown) as TypeInRawJsonSchema<K>;
 }
 
 /**
  * All allowed string keys supporting string values (but may also support other value types).
  */
 export type KeysOfRawJsonSchemaWithValuesOf<T> = Extract<
-    KeysWithValueType<JSONSchema4, T> | KeysWithValueType<JSONSchema6, T> | KeysWithValueType<JSONSchema7, T> | KeysWithValueType<JSONSchema8, T>,
+    | KeysWithValueType<JSONSchema4, T>
+    | KeysWithValueType<JSONSchema6, T>
+    | KeysWithValueType<JSONSchema7, T>
+    | KeysWithValueType<JSONSchema201909, T>,
     string
 >;
 

--- a/test/model/schemaUtils.test.ts
+++ b/test/model/schemaUtils.test.ts
@@ -30,14 +30,18 @@ describe("createGroupFromSchema()", () => {
         expect(result.entries).toHaveLength(1);
         expect(result.entries[0]).toBe(schema);
     });
-    it("returns allOf group with entry itself and referenced schema", () => {
+    it.each`
+        referenceKeyword
+        ${"$ref"}
+        ${"$recursiveRef"}
+    `("returns allOf group with entry itself and referenced schema (via $referenceKeyword)", ({ referenceKeyword }) => {
         const { scope } = new JsonSchema(
             {
                 $defs: { Foo: rawFooSchema }
             },
             {}
         );
-        const rawTargetSchema = { $ref: "#/$defs/Foo" };
+        const rawTargetSchema = { [referenceKeyword]: "#/$defs/Foo" };
         const schema = new JsonSchema(rawTargetSchema, {}, scope);
         const result = createGroupFromSchema(schema);
         expect(result.entries).toHaveLength(2);


### PR DESCRIPTION
- Draft 2019-09: basic support for `$recursiveRef` as alias for `$ref` (not yet covering advanced use cases)
- Include type definition for Draft 2019-09 for expected props